### PR TITLE
fix JDBC connection does not auto reconnect issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.casbin</groupId>
     <artifactId>jdbc-adapter</artifactId>
-    <version>1.1.2-FIX</version>
+    <version>1.1.3</version>
 
     <name>JDBC Adapter for JCasbin</name>
     <description>Load policy from JDBC supported database or save policy to it</description>

--- a/src/main/java/org/casbin/adapter/JDBCAdapter.java
+++ b/src/main/java/org/casbin/adapter/JDBCAdapter.java
@@ -106,11 +106,11 @@ public class JDBCAdapter implements Adapter {
             Class.forName(driver);
 
             if (dbSpecified) {
-                conn = DriverManager.getConnection(url + "?rewriteBatchedStatements=true", username, password);
+                conn = DriverManager.getConnection(url + "?rewriteBatchedStatements=true&autoReconnect=true", username, password);
             } else {
                 createDatabase();
 
-                conn = DriverManager.getConnection(url + "casbin" + "?rewriteBatchedStatements=true", username, password);
+                conn = DriverManager.getConnection(url + "casbin" + "?rewriteBatchedStatements=true&autoReconnect=true", username, password);
             }
 
         } catch (ClassNotFoundException | SQLException e) {


### PR DESCRIPTION
When backend jdbc connection is broken (e.g: intermittent network issue), the connection is not re-established, causing subsequent calls to addPolicy or savePolicy to fail.