### PR TITLE
You need to add the time zone configuration at instantiation time, otherwise an exception will be thrown, and with the time zone configuration added, an exception will be thrown here

### DIFF
--- a/src/main/java/org/casbin/adapter/JDBCAdapter.java
+++ b/src/main/java/org/casbin/adapter/JDBCAdapter.java
@@ -115,7 +115,12 @@ public class JDBCAdapter implements Adapter {
 
     private String getUrl(){
         if (getDataSource().equals(mysql)){
-            return url + "?rewriteBatchedStatements=true&autoReconnect=true";
+            if (url.contains("?")){
+                url = url + "&";
+            }else {
+                url = url + "?";
+            }
+            return url + "rewriteBatchedStatements=true&autoReconnect=true";
         }
         return url;
     }


### PR DESCRIPTION
https://github.com/jcasbin/jdbc-adapter/issues/2
I also encountered this problem, which still exists in the latest version:
```
<dependency>
            <groupId>org.casbin</groupId>
            <artifactId>jdbc-adapter</artifactId>
            <version>1.1.3</version>
        </dependency>
```
(When introducing this package, follow the official example)
```
JDBCAdapter a = new JDBCAdapter("com.mysql.cj.jdbc.Driver", "jdbc:mysql://localhost:3306/", "root", "123");
or
JDBCAdapter a = new JDBCAdapter("com.mysql.cj.jdbc.Driver", "jdbc:mysql://localhost:3306/casbin", "root", "123", true);
```
It throws an exception
```
java.sql.SQLNonTransientConnectionException: Could not create connection to database server. Attempted reconnect 3 times. Giving up.
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:110)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:89)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:63)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:73)
	at com.mysql.cj.jdbc.ConnectionImpl.connectWithRetries(ConnectionImpl.java:897)
	at com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:822)
	at com.mysql.cj.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:447)
	at com.mysql.cj.jdbc.ConnectionImpl.getInstance(ConnectionImpl.java:237)
	at com.mysql.cj.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java:199)
	at java.sql.DriverManager.getConnection(DriverManager.java:664)
	at java.sql.DriverManager.getConnection(DriverManager.java:247)
	at org.casbin.adapter.JDBCAdapter.open(JDBCAdapter.java:109)
	at org.casbin.adapter.JDBCAdapter.<init>(JDBCAdapter.java:85)
	at cn.com.chengzi.access.control.domain.JCasbinTest.main(JCasbinTest.java:18)
Caused by: com.mysql.cj.exceptions.InvalidConnectionAttributeException: The server time zone value '�й���׼ʱ��' is unrecognized or represents more than one time zone. You must configure either the server or JDBC driver (via the serverTimezone configuration property) to use a more specifc time zone value if you want to utilize time zone support.
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:61)
	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:85)
	at com.mysql.cj.util.TimeUtil.getCanonicalTimezone(TimeUtil.java:132)
	at com.mysql.cj.protocol.a.NativeProtocol.configureTimezone(NativeProtocol.java:2139)
	at com.mysql.cj.protocol.a.NativeProtocol.initServerSession(NativeProtocol.java:2163)
	at com.mysql.cj.jdbc.ConnectionImpl.initializePropsFromServer(ConnectionImpl.java:1301)
	at com.mysql.cj.jdbc.ConnectionImpl.connectWithRetries(ConnectionImpl.java:860)
	... 9 more
Exception in thread "main" java.lang.NullPointerException
	at org.casbin.adapter.JDBCAdapter.createTable(JDBCAdapter.java:134)
	at org.casbin.adapter.JDBCAdapter.open(JDBCAdapter.java:120)
	at org.casbin.adapter.JDBCAdapter.<init>(JDBCAdapter.java:85)
	at cn.com.chengzi.access.control.domain.JCasbinTest.main(JCasbinTest.java:18)
```
Obviously, we need to add time zone configuration
The configuration that is modified is as follows:
```
JDBCAdapter a = new JDBCAdapter("com.mysql.cj.jdbc.Driver", "jdbc:mysql://localhost:3306/casbin?serverTimezone=UTC", "root", "123", true);
```
At this point, an exception described by the originator of `issues` is thrown
```
java.sql.SQLNonTransientConnectionException: Could not create connection to database server. Attempted reconnect 3 times. Giving up.
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:110)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:89)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:63)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:73)
	at com.mysql.cj.jdbc.ConnectionImpl.connectWithRetries(ConnectionImpl.java:897)
	at com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:822)
	at com.mysql.cj.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:447)
	at com.mysql.cj.jdbc.ConnectionImpl.getInstance(ConnectionImpl.java:237)
	at com.mysql.cj.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java:199)
	at java.sql.DriverManager.getConnection(DriverManager.java:664)
	at java.sql.DriverManager.getConnection(DriverManager.java:247)
	at org.casbin.adapter.JDBCAdapter.open(JDBCAdapter.java:109)
	at org.casbin.adapter.JDBCAdapter.<init>(JDBCAdapter.java:85)
	at cn.com.chengzi.access.control.domain.JCasbinTest.main(JCasbinTest.java:18)
Caused by: com.mysql.cj.exceptions.WrongArgumentException: No timezone mapping entry for 'UTC?rewriteBatchedStatements=true'
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:61)
	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:85)
	at com.mysql.cj.protocol.a.NativeProtocol.configureTimezone(NativeProtocol.java:2153)
	at com.mysql.cj.protocol.a.NativeProtocol.initServerSession(NativeProtocol.java:2163)
	at com.mysql.cj.jdbc.ConnectionImpl.initializePropsFromServer(ConnectionImpl.java:1301)
	at com.mysql.cj.jdbc.ConnectionImpl.connectWithRetries(ConnectionImpl.java:860)
	... 9 more
Exception in thread "main" java.lang.NullPointerException
	at org.casbin.adapter.JDBCAdapter.createTable(JDBCAdapter.java:134)
	at org.casbin.adapter.JDBCAdapter.open(JDBCAdapter.java:120)
	at org.casbin.adapter.JDBCAdapter.<init>(JDBCAdapter.java:85)
	at cn.com.chengzi.access.control.domain.JCasbinTest.main(JCasbinTest.java:18)
```
Does the code not determine whether 'already exists in' url '? ', resulting in configuration error