### PR TITLE
add constructor with javax.sql.DataSource passed in

### DIFF
--- a/src/main/java/org/casbin/adapter/JDBCAdapter.java
+++ b/src/main/java/org/casbin/adapter/JDBCAdapter.java
@@ -20,6 +20,7 @@ import org.casbin.jcasbin.model.Model;
 import org.casbin.jcasbin.persist.Adapter;
 import org.casbin.jcasbin.persist.Helper;
 
+import javax.sql.DataSource;
 import java.sql.*;
 import java.util.*;
 
@@ -85,6 +86,20 @@ public class JDBCAdapter implements Adapter {
         this.dbSpecified = dbSpecified;
 
         open();
+    }
+
+    /**
+     * JDBCAdapter is the constructor for JDBCAdapter, will not try to create database.
+     *
+     * @param dataSource the JDBC DataSource.
+     */
+    public JDBCAdapter(DataSource dataSource) {
+        try {
+            this.conn = dataSource.getConnection();
+            createTable();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
     }
 
     public void finalize() {

--- a/src/main/java/org/casbin/adapter/JDBCAdapter.java
+++ b/src/main/java/org/casbin/adapter/JDBCAdapter.java
@@ -96,6 +96,7 @@ public class JDBCAdapter implements Adapter {
     public JDBCAdapter(DataSource dataSource) {
         try {
             this.conn = dataSource.getConnection();
+            this.url = this.conn.getMetaData().getURL();
             createTable();
         } catch (SQLException e) {
             e.printStackTrace();

--- a/src/test/java/org/casbin/adapter/JDBCAdapterTest.java
+++ b/src/test/java/org/casbin/adapter/JDBCAdapterTest.java
@@ -14,10 +14,12 @@
 
 package org.casbin.adapter;
 
+import com.mysql.cj.jdbc.MysqlDataSource;
 import org.casbin.jcasbin.main.Enforcer;
 import org.casbin.jcasbin.util.Util;
 import org.junit.Test;
 
+import javax.sql.DataSource;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -35,6 +37,15 @@ public class JDBCAdapterTest {
         if (!Util.array2DEquals(res, myRes)) {
             fail("Policy: " + myRes + ", supposed to be " + res);
         }
+    }
+
+    private DataSource genDataSource() {
+        MysqlDataSource dataSource = new MysqlDataSource();
+        dataSource.setUrl("jdbc:mysql://localhost:3306/casbin");
+        dataSource.setDatabaseName("casbin");
+        dataSource.setUser("root");
+        dataSource.setPassword("");
+        return dataSource;
     }
 
     @Test
@@ -67,7 +78,7 @@ public class JDBCAdapterTest {
         // Now the DB has policy, so we can provide a normal use case.
         // Create an adapter and an enforcer.
         // new Enforcer() will load the policy automatically.
-        a = new JDBCAdapter("com.mysql.cj.jdbc.Driver", "jdbc:mysql://localhost:3306/", "root", "");
+        a = new JDBCAdapter(genDataSource());
         e = new Enforcer("examples/rbac_model.conf", a);
         testGetPolicy(e, asList(
                 asList("alice", "data1", "read"),


### PR DESCRIPTION
用户传入其配置的ds一般带database，而只有这个datasource无法切database重获conn，所以这个新加的ctor没有dbSpecified选项。
----------
Add a new constructor with javax.sql.DataSource passed in. Unlike the other constructors, this one will not try to create database by default, create your own database beforehand and specify it during DataSource creation.
