### PR TITLE
Introduce basic retry for database actions

### DIFF
--- a/src/main/java/org/casbin/adapter/JDBCAdapter.java
+++ b/src/main/java/org/casbin/adapter/JDBCAdapter.java
@@ -99,38 +99,37 @@ public class JDBCAdapter extends JDBCBaseAdapter implements FilteredAdapter {
      * loadFilteredPolicyFile loads only policy rules that match the filter from file.
      */
     private void loadFilteredPolicyFile(Model model, Filter filter, Helper.loadPolicyLineHandler<String, Model> handler) throws CasbinAdapterException {
-        try (Statement stmt = conn.createStatement()) {
-            ResultSet rSet = stmt.executeQuery("SELECT * FROM casbin_rule");
-            ResultSetMetaData rData = rSet.getMetaData();
-            while (rSet.next()) {
-                CasbinRule line = new CasbinRule();
-                for (int i = 1; i <= rData.getColumnCount(); i++) {
-                    if (i == 2) {
-                        line.ptype = rSet.getObject(i) == null ? "" : (String) rSet.getObject(i);
-                    } else if (i == 3) {
-                        line.v0 = rSet.getObject(i) == null ? "" : (String) rSet.getObject(i);
-                    } else if (i == 4) {
-                        line.v1 = rSet.getObject(i) == null ? "" : (String) rSet.getObject(i);
-                    } else if (i == 5) {
-                        line.v2 = rSet.getObject(i) == null ? "" : (String) rSet.getObject(i);
-                    } else if (i == 6) {
-                        line.v3 = rSet.getObject(i) == null ? "" : (String) rSet.getObject(i);
-                    } else if (i == 7) {
-                        line.v4 = rSet.getObject(i) == null ? "" : (String) rSet.getObject(i);
-                    } else if (i == 8) {
-                        line.v5 = rSet.getObject(i) == null ? "" : (String) rSet.getObject(i);
+        attemptWithRetries(JDBCBaseAdapter._DEFAULT_CONNECTION_TRIES, () -> {
+            try (Statement stmt = this.conn.createStatement()) {
+                ResultSet rSet = stmt.executeQuery("SELECT * FROM casbin_rule");
+                ResultSetMetaData rData = rSet.getMetaData();
+                while (rSet.next()) {
+                    CasbinRule line = new CasbinRule();
+                    for (int i = 1; i <= rData.getColumnCount(); i++) {
+                        if (i == 2) {
+                            line.ptype = rSet.getObject(i) == null ? "" : (String) rSet.getObject(i);
+                        } else if (i == 3) {
+                            line.v0 = rSet.getObject(i) == null ? "" : (String) rSet.getObject(i);
+                        } else if (i == 4) {
+                            line.v1 = rSet.getObject(i) == null ? "" : (String) rSet.getObject(i);
+                        } else if (i == 5) {
+                            line.v2 = rSet.getObject(i) == null ? "" : (String) rSet.getObject(i);
+                        } else if (i == 6) {
+                            line.v3 = rSet.getObject(i) == null ? "" : (String) rSet.getObject(i);
+                        } else if (i == 7) {
+                            line.v4 = rSet.getObject(i) == null ? "" : (String) rSet.getObject(i);
+                        } else if (i == 8) {
+                            line.v5 = rSet.getObject(i) == null ? "" : (String) rSet.getObject(i);
+                        }
                     }
+                    if (filterLine(line, filter)) {
+                        continue;
+                    }
+                    loadPolicyLine(line, model);
                 }
-                if (filterLine(line, filter)) {
-                    continue;
-                }
-                loadPolicyLine(line, model);
+                rSet.close();
             }
-            rSet.close();
-        } catch (SQLException e) {
-            e.printStackTrace();
-            throw new Error(e);
-        }
+        });
     }
 
     /**


### PR DESCRIPTION
This is a first proposal for fixing #32 

The current version of this code will attempt to retry the same operation x times (default: 3 attempts), after which it throws the last SQLException it encountered. I did not find a way to simply try infinitely as mentioned in https://github.com/jcasbin/jdbc-adapter/issues/32#issuecomment-822393702 without blocking the thread or introducing new dependencies to do this asynchronously.

Issues:
- I was unable to run the tests locally, due to relying on locally running versions of databases, and therefore can't ensure validity of the code
- If no new connection can be made (e.g. database still down), the code will return an SQLException immediately, without retrying. See https://github.com/lanmarti/jdbc-adapter/blob/9bf8f34274b2e9a26d942426f782fd2838b58b02/src/main/java/org/casbin/adapter/JDBCBaseAdapter.java#L110-L116
I think it would be better to have a customizable delay here that attempts to reconnect after a customizable timeout.

Due to the synchronous nature of the calls, I'm a bit stuck. I'm used to doing this sort of stuff using asynchronous calls and through promises/futures, however that does not seem to be an option here. I could make the connection retry block the thread for the duration of the timeout, but that does not seem like a good solution to me.

Feel free to comment/change/... as needed!
