### PR TITLE
fix: if MySQL, check the existence of the table.

### DIFF
--- a/src/main/java/org/casbin/adapter/JDBCBaseAdapter.java
+++ b/src/main/java/org/casbin/adapter/JDBCBaseAdapter.java
@@ -79,6 +79,13 @@ abstract class JDBCBaseAdapter implements Adapter {
         String productName = conn.getMetaData().getDatabaseProductName();
 
         switch (productName) {
+            case "MySQL":
+                String hasTableSql = "SHOW TABLES LIKE 'casbin_rule';";
+                ResultSet rs = stmt.executeQuery(hasTableSql);
+                if (rs.next()) {
+                    return;
+                }
+                break;
             case "Oracle":
                 sql = "declare begin execute immediate 'CREATE TABLE CASBIN_RULE(id NUMBER(5, 0) not NULL primary key, ptype VARCHAR(100) not NULL, v0 VARCHAR(100), v1 VARCHAR(100), v2 VARCHAR(100), v3 VARCHAR(100), v4 VARCHAR(100), v5 VARCHAR(100))'; " +
                         "exception when others then " +


### PR DESCRIPTION
I'm using this tool in my product.
However, the CREATE statement cannot be executed due to the restricted user rights of the DB.
Therefore, if I'm using MySQL, this tool needs to check the existence of the table first.

In this PR, if productName is "MySQL", the SHOW TABLE statement will check for the existence of the table.
If the table exists, no further migration will be performed.