### PR TITLE
ci: remove semantic-release auto publishing

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -67,19 +67,3 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 20
-
-      - name: Semantic Release
-        run: |
-          npm install -g @conveyal/maven-semantic-release semantic-release
-          semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github,@conveyal/maven-semantic-release --verify-release @conveyal/maven-semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_KEY_NAME: ${{ secrets.GPG_KEY_NAME }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          OSSRH_JIRA_USERNAME: ${{ secrets.OSSRH_JIRA_USERNAME }}
-          OSSRH_JIRA_PASSWORD: ${{ secrets.OSSRH_JIRA_PASSWORD }}


### PR DESCRIPTION
## Summary

Related: apache/casbin#1747

As requested in [apache/casbin#1747](https://github.com/apache/casbin/issues/1747),
semantic-release should no longer auto-publish new versions to GitHub Releases
and package registries. New releases will instead be voted on by the community
and published manually via
[incubator-release-assistant](https://github.com/casdoor/incubator-release-assistant).

Changes:
- remove the `Set up Node.js` and `Semantic Release` steps from
  `.github/workflows/maven-ci.yml`, which ran semantic-release on every push
  to auto-publish to GitHub Releases and Maven Central
- remove the now-unused secrets (`GITHUB_TOKEN`, `GPG_KEY_NAME`,
  `GPG_PASSPHRASE`, `OSSRH_JIRA_USERNAME`, `OSSRH_JIRA_PASSWORD`)
- keep the build/test pipeline (MySQL / PostgreSQL / SQL Server matrix) and
  the Codecov upload unchanged

The `central-publishing-maven-plugin` in `pom.xml` is kept, as it is still
useful for manual releases.

## Verification

- `mvn clean compile` passes locally with JDK 1.8
- no Java source code or Maven configuration is changed
- CI still runs `mvn clean test cobertura:cobertura` against the
  MySQL / PostgreSQL / SQL Server matrix, to be confirmed by GitHub Actions
  on this PR